### PR TITLE
Reproducer for unresolved BuildConfig when using enableBuildConfigAsBytecode.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,9 +18,13 @@ android {
     versionCode = 1
     versionName = "1.0.0"
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+    // Either uncomment the next line to fix the compilation error.
+    // buildConfigField("String", "WORKAROUND", "\"foo\"")
   }
 
   buildFeatures {
+    buildConfig = true
     viewBinding = true
   }
 

--- a/app/src/test/kotlin/com/vanniktech/playground/EmptyUnitTest.kt
+++ b/app/src/test/kotlin/com/vanniktech/playground/EmptyUnitTest.kt
@@ -1,9 +1,10 @@
 package com.vanniktech.playground
 
 import org.junit.Test
+import kotlin.test.assertEquals
 
 class EmptyUnitTest {
   @Test fun empty() {
-    
+    assertEquals(true, BuildConfig.DEBUG)
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,7 @@ org.gradle.jvmargs=-Xmx1536m
 
 kotlin.mpp.stability.nowarn=true
 
+# Or turn this new feature off.
+android.enableBuildConfigAsBytecode=true
+
 kotlin.mpp.androidSourceSetLayoutVersion=2


### PR DESCRIPTION
https://issuetracker.google.com/issues/363031540